### PR TITLE
docs: update discord invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can find the following documentation:
 * A [guide](https://docs.oss-monitoring.radicalbit.ai/user-guide/quickstart) that walks users through creating dashboards on the platform.
 
 ## 🤝 Community
-Please join us on our [Discord server](https://discord.com/invite/pApadedx), to discuss the platform, share ideas, and help shape its future! Get help from experts and fellow users.
+Please join us on our [Discord server](https://discord.gg/x2Ze8TMRsD), to discuss the platform, share ideas, and help shape its future! Get help from experts and fellow users.
 
 ## 📦 Functionalities & Roadmap
 We've released a first dashboard, covering Binary Classification models for tabular data.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -114,7 +114,7 @@ const config = {
             items: [
               {
                 label: 'Discord',
-                href: 'https://discord.gg/pApadedx',
+                href: 'https://discord.gg/x2Ze8TMRsD',
               },
             ],
           }


### PR DESCRIPTION
As title, the old link is no more valid or will expire shortly