### PR TITLE
docs: added security scan result to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 ![GitHub Release](https://img.shields.io/github/v/release/radicalbit/radicalbit-ai-monitoring)
 ![GitHub License](https://img.shields.io/github/license/radicalbit/radicalbit-ai-monitoring)
 ![Discord](https://img.shields.io/discord/1252978922962817034)
+[![Security Scan](https://img.shields.io/github/actions/workflow/status/radicalbit/radicalbit-ai-monitoring/trivy-scan.yaml?branch=main&label=Security%20Scan
+)](./.github/workflows/trivy-scan.yaml)
 
 # Radicalbit AI Monitoring
 


### PR DESCRIPTION
As title, this will add security scan badges to README.md.

This can even be achieved by [github workflow status badges](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge) but to maintain the same theme i used shield.io.

The README.md file will look like this one this is merged:
<img width="680" alt="Screenshot 2024-06-25 alle 09 19 23" src="https://github.com/radicalbit/radicalbit-ai-monitoring/assets/127778257/674e2311-3621-4906-bb02-695a61cb8926">
