### PR TITLE
ci: convert from automatic to manual releases

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,7 +1,4 @@
-on:
-  push:
-    branches:
-      - main
+on: workflow_dispatch
 
 permissions:
   contents: write


### PR DESCRIPTION
We're at the beginning of our journey and we think that, in this situation, an automatic way of releasing is not the proper one. A manual release gives us the certainty of creating bullet-proof releases, while in the meantime we work hard to improve all the rest (i.e. testing, qa etc. etc.) as automatic releases will anyway be our standard in the next future.