### PR TITLE
ci: only push to dockerhub on git tag with additional 'latest' tag

### DIFF
--- a/.github/workflows/api-workflow.yaml
+++ b/.github/workflows/api-workflow.yaml
@@ -50,11 +50,12 @@ jobs:
     if: github.event_name != 'pull_request'
     uses: radicalbit/radicalbit-github-workflows/.github/workflows/docker.yaml@v1
     with:
-      push: ${{ github.event_name != 'pull_request' }}
+      push: ${{ startsWith(github.ref, 'refs/tags/v') }}
       context: ./api
       image: radicalbit-ai-monitoring-api
-      tag: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'latest' }}
+      tag: github.ref_name
       dockerhub_shortdesc: "Radicalbit AI Monitoring - backend API"
+      dockerhub_push_latest: true
     secrets:
       USERNAME: ${{ secrets.DOCKER_HUB_USER }}
       PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}

--- a/.github/workflows/migrations-workflow.yaml
+++ b/.github/workflows/migrations-workflow.yaml
@@ -66,12 +66,13 @@ jobs:
     if: github.event_name != 'pull_request'
     uses: radicalbit/radicalbit-github-workflows/.github/workflows/docker.yaml@v1
     with:
-      push: ${{ github.event_name != 'pull_request' }}
+      push: ${{ startsWith(github.ref, 'refs/tags/v') }}
       context: ./api
       dockerfile: migrations.Dockerfile
       image: radicalbit-ai-monitoring-migrations
-      tag: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'latest' }}
+      tag: github.ref_name
       dockerhub_shortdesc: "Radicalbit AI Monitoring - database migrations"
+      dockerhub_push_latest: true
     secrets:
       USERNAME: ${{ secrets.DOCKER_HUB_USER }}
       PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}

--- a/.github/workflows/spark-workflow.yaml
+++ b/.github/workflows/spark-workflow.yaml
@@ -51,11 +51,12 @@ jobs:
     if: github.event_name != 'pull_request'
     uses: radicalbit/radicalbit-github-workflows/.github/workflows/docker.yaml@v1
     with:
-      push: ${{ github.event_name != 'pull_request' }}
+      push: ${{ startsWith(github.ref, 'refs/tags/v') }}
       context: ./spark
       image: radicalbit-spark-py
-      tag: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'latest' }}
+      tag: github.ref_name
       dockerhub_shortdesc: "Radicalbit AI Monitoring - Apache Spark jobs"
+      dockerhub_push_latest: true
     secrets:
       USERNAME: ${{ secrets.DOCKER_HUB_USER }}
       PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}

--- a/.github/workflows/ui-workflow.yaml
+++ b/.github/workflows/ui-workflow.yaml
@@ -19,11 +19,12 @@ jobs:
     if: github.event_name != 'pull_request'
     uses: radicalbit/radicalbit-github-workflows/.github/workflows/docker.yaml@v1
     with:
-      push: ${{ github.event_name != 'pull_request' }}
+      push: ${{ startsWith(github.ref, 'refs/tags/v') }}
       context: ./ui
       image: radicalbit-ai-monitoring-ui
-      tag: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'latest' }}
+      tag: github.ref_name
       dockerhub_shortdesc: "Radicalbit AI Monitoring - frontend UI"
+      dockerhub_push_latest: true
     secrets:
       USERNAME: ${{ secrets.DOCKER_HUB_USER }}
       PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}


### PR DESCRIPTION
As title, for every docker hub image that we push the workflow has been modified so that:

* We only build the docker image on `main` branch pushes
* In case of a git tag:
   * We push a docker image tagged with the `ref_name` of the git tag i.e. `v0.8.2`
   * We push a docker image tagged with `latest` tag
   
The idea is that, on Docker Hub, the `latest` tag is **always** pushed/associated to a "git" tag.


**We must merge this one only after we merge https://github.com/radicalbit/radicalbit-github-workflows/pull/19**