### PR TITLE
ci: publish 'develop' images when main pushed

### DIFF
--- a/.github/workflows/api-workflow.yaml
+++ b/.github/workflows/api-workflow.yaml
@@ -50,12 +50,12 @@ jobs:
     if: github.event_name != 'pull_request'
     uses: radicalbit/radicalbit-github-workflows/.github/workflows/docker.yaml@v1
     with:
-      push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      push: ${{ github.event_name != 'pull_request' }}
       context: ./api
       image: radicalbit-ai-monitoring-api
-      tag: github.ref_name
+      tag: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'develop' }}
       dockerhub_shortdesc: "Radicalbit AI Monitoring - backend API"
-      dockerhub_push_latest: true
+      dockerhub_push_latest: ${{ startsWith(github.ref, 'refs/tags/v') }}
     secrets:
       USERNAME: ${{ secrets.DOCKER_HUB_USER }}
       PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}

--- a/.github/workflows/migrations-workflow.yaml
+++ b/.github/workflows/migrations-workflow.yaml
@@ -66,13 +66,13 @@ jobs:
     if: github.event_name != 'pull_request'
     uses: radicalbit/radicalbit-github-workflows/.github/workflows/docker.yaml@v1
     with:
-      push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      push: ${{ github.event_name != 'pull_request' }}
       context: ./api
       dockerfile: migrations.Dockerfile
       image: radicalbit-ai-monitoring-migrations
-      tag: github.ref_name
+      tag: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'develop' }}
       dockerhub_shortdesc: "Radicalbit AI Monitoring - database migrations"
-      dockerhub_push_latest: true
+      dockerhub_push_latest: ${{ startsWith(github.ref, 'refs/tags/v') }}
     secrets:
       USERNAME: ${{ secrets.DOCKER_HUB_USER }}
       PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}

--- a/.github/workflows/spark-workflow.yaml
+++ b/.github/workflows/spark-workflow.yaml
@@ -51,12 +51,12 @@ jobs:
     if: github.event_name != 'pull_request'
     uses: radicalbit/radicalbit-github-workflows/.github/workflows/docker.yaml@v1
     with:
-      push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      push: ${{ github.event_name != 'pull_request' }}
       context: ./spark
       image: radicalbit-spark-py
-      tag: github.ref_name
+      tag: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'develop' }}
       dockerhub_shortdesc: "Radicalbit AI Monitoring - Apache Spark jobs"
-      dockerhub_push_latest: true
+      dockerhub_push_latest: ${{ startsWith(github.ref, 'refs/tags/v') }}
     secrets:
       USERNAME: ${{ secrets.DOCKER_HUB_USER }}
       PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}

--- a/.github/workflows/ui-workflow.yaml
+++ b/.github/workflows/ui-workflow.yaml
@@ -19,12 +19,12 @@ jobs:
     if: github.event_name != 'pull_request'
     uses: radicalbit/radicalbit-github-workflows/.github/workflows/docker.yaml@v1
     with:
-      push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      push: ${{ github.event_name != 'pull_request' }}
       context: ./ui
       image: radicalbit-ai-monitoring-ui
-      tag: github.ref_name
+      tag: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'develop' }}
       dockerhub_shortdesc: "Radicalbit AI Monitoring - frontend UI"
-      dockerhub_push_latest: true
+      dockerhub_push_latest: ${{ startsWith(github.ref, 'refs/tags/v') }}
     secrets:
       USERNAME: ${{ secrets.DOCKER_HUB_USER }}
       PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}


### PR DESCRIPTION
As title, all actions that push docker images are modified so that:

* The push action happens only when a branch is pushed
* The Docker image tag will be:
   * `develop` when the `main` branch is pushed
   * the git tag name i.e. `vX.Y.Z` when the git tag `vX.Y.Z` is pushed
* The `latest` docker tag is pushed only when a git tag is pushed