### PR TITLE
feat: add text-generation as new model type

### DIFF
--- a/api/tests/commons/db_mock.py
+++ b/api/tests/commons/db_mock.py
@@ -33,10 +33,10 @@ def get_sample_model(
     model_type: str = ModelType.BINARY.value,
     data_type: str = DataType.TEXT.value,
     granularity: str = Granularity.DAY.value,
-    features: List[Dict] = [
+    features: Optional[List[Dict]] = [
         {'name': 'feature1', 'type': 'string', 'fieldType': 'categorical'}
     ],
-    outputs: Dict = {
+    outputs: Optional[Dict] = {
         'prediction': {'name': 'pred1', 'type': 'int', 'fieldType': 'numerical'},
         'prediction_proba': {
             'name': 'prob1',
@@ -45,8 +45,12 @@ def get_sample_model(
         },
         'output': [{'name': 'output1', 'type': 'string', 'fieldType': 'categorical'}],
     },
-    target: Dict = {'name': 'target1', 'type': 'string', 'fieldType': 'categorical'},
-    timestamp: Dict = {
+    target: Optional[Dict] = {
+        'name': 'target1',
+        'type': 'string',
+        'fieldType': 'categorical',
+    },
+    timestamp: Optional[Dict] = {
         'name': 'timestamp',
         'type': 'datetime',
         'fieldType': 'datetime',
@@ -91,14 +95,14 @@ def get_sample_model_in(
     model_type: str = ModelType.BINARY.value,
     data_type: str = DataType.TEXT.value,
     granularity: str = Granularity.DAY.value,
-    features: List[ColumnDefinition] = [
+    features: Optional[List[ColumnDefinition]] = [
         ColumnDefinition(
             name='feature1',
             type=SupportedTypes.string,
             field_type=FieldType.categorical,
         )
     ],
-    outputs: OutputType = OutputType(
+    outputs: Optional[OutputType] = OutputType(
         prediction=ColumnDefinition(
             name='pred1', type=SupportedTypes.int, field_type=FieldType.numerical
         ),
@@ -113,10 +117,10 @@ def get_sample_model_in(
             )
         ],
     ),
-    target: ColumnDefinition = ColumnDefinition(
+    target: Optional[ColumnDefinition] = ColumnDefinition(
         name='target1', type=SupportedTypes.int, field_type=FieldType.numerical
     ),
-    timestamp: ColumnDefinition = ColumnDefinition(
+    timestamp: Optional[ColumnDefinition] = ColumnDefinition(
         name='timestamp', type=SupportedTypes.datetime, field_type=FieldType.datetime
     ),
     frameworks: Optional[str] = None,

--- a/api/tests/commons/modelin_factory.py
+++ b/api/tests/commons/modelin_factory.py
@@ -25,6 +25,64 @@ def get_model_sample_wrong(fail_fields: List[str], model_type: ModelType):
         name='timestamp', type=SupportedTypes.datetime, field_type=FieldType.datetime
     )
 
+    if model_type == ModelType.TEXT_GENERATION:
+        if 'features' in fail_fields:
+            features = [
+                ColumnDefinition(
+                    name='feature1',
+                    type=SupportedTypes.string,
+                    field_type=FieldType.categorical,
+                )
+            ]
+        else:
+            features = None
+
+        if 'outputs' in fail_fields:
+            outputs = OutputType(
+                prediction=prediction,
+                prediction_proba=prediction_proba,
+                output=[
+                    ColumnDefinition(
+                        name='output1',
+                        type=SupportedTypes.string,
+                        field_type=FieldType.categorical,
+                    )
+                ],
+            )
+        else:
+            outputs = None
+
+        if 'target' in fail_fields:
+            target = ColumnDefinition(
+                name='target1',
+                type=SupportedTypes.string,
+                field_type=FieldType.categorical,
+            )
+        else:
+            target = None
+
+        if 'timestamp' in fail_fields:
+            timestamp = ColumnDefinition(
+                name='timestamp',
+                type=SupportedTypes.string,
+                field_type=FieldType.categorical,
+            )
+        else:
+            timestamp = None
+
+        return {
+            'name': 'text_generation_model',
+            'model_type': model_type,
+            'data_type': DataType.TEXT,
+            'granularity': Granularity.DAY,
+            'features': features,
+            'outputs': outputs,
+            'target': target,
+            'timestamp': timestamp,
+            'frameworks': None,
+            'algorithm': None,
+        }
+
     if 'outputs.prediction' in fail_fields:
         if model_type == ModelType.BINARY:
             prediction = ColumnDefinition(

--- a/api/tests/services/model_service_test.py
+++ b/api/tests/services/model_service_test.py
@@ -11,7 +11,7 @@ from app.db.dao.model_dao import ModelDAO
 from app.db.dao.reference_dataset_dao import ReferenceDatasetDAO
 from app.models.alert_dto import AnomalyType
 from app.models.exceptions import ModelError, ModelNotFoundError
-from app.models.model_dto import ModelOut
+from app.models.model_dto import ModelOut, ModelType
 from app.models.model_order import OrderType
 from app.services.model_service import ModelService
 from tests.commons import db_mock
@@ -37,6 +37,27 @@ class ModelServiceTest(unittest.TestCase):
         model = db_mock.get_sample_model()
         self.model_dao.insert = MagicMock(return_value=model)
         model_in = db_mock.get_sample_model_in()
+        res = self.model_service.create_model(model_in)
+        self.model_dao.insert.assert_called_once()
+
+        assert res == ModelOut.from_model(model)
+
+    def test_create_text_generation_model_ok(self):
+        model = db_mock.get_sample_model(
+            model_type=ModelType.TEXT_GENERATION,
+            features=None,
+            target=None,
+            outputs=None,
+            timestamp=None,
+        )
+        self.model_dao.insert = MagicMock(return_value=model)
+        model_in = db_mock.get_sample_model_in(
+            model_type=ModelType.TEXT_GENERATION,
+            features=None,
+            target=None,
+            outputs=None,
+            timestamp=None,
+        )
         res = self.model_service.create_model(model_in)
         self.model_dao.insert.assert_called_once()
 


### PR DESCRIPTION
First step in introducing the new model type TEXT_GENERATION.
I defined the schema fields as optional when creating the model.
Further modifications will follow to enable the new flow.